### PR TITLE
bugfix-overlay-position

### DIFF
--- a/lib/src/pinch_zoom_release_unzoom_widget.dart
+++ b/lib/src/pinch_zoom_release_unzoom_widget.dart
@@ -253,7 +253,10 @@ class _PinchZoomReleaseUnzoomWidgetState
       rootOverlay: widget.rootOverlay,
     );
     final RenderBox renderBox = context.findRenderObject()! as RenderBox;
-    final Offset offset = renderBox.localToGlobal(Offset.zero);
+    final Offset offset = renderBox.localToGlobal(
+      Offset.zero,
+      ancestor: overlay.context.findRenderObject(),
+    );
 
     entry = OverlayEntry(builder: (context) {
       final double opacity = ((scale - 1) / (widget.maxScale - 1))


### PR DESCRIPTION
Inside nested navigator, overlay position can be wrong.  During the pinch to zoom, we can see the widget behind the zooming one...
Adding ancestor parameter ensure that positions from child and pinched child are well sync.